### PR TITLE
Fix dataset directory path for script execution

### DIFF
--- a/scripts/download-dataset.py
+++ b/scripts/download-dataset.py
@@ -1,11 +1,25 @@
 import os, zipfile
 from huggingface_hub import snapshot_download
 
-if not(os.path.exists("datasets/osv5m")):
-    os.mkdir("datasets/osv5m")
+# Define the base directory
+base_dir = os.path.join(os.getcwd(), 'datasets')
 
-snapshot_download(repo_id="osv5m/osv5m", local_dir="datasets/osv5m", repo_type='dataset')
-for root, dirs, files in os.walk("datasets/osv5m"):
+# Ensure the base directory exists
+if not os.path.exists(base_dir):
+    os.mkdir(base_dir)
+
+# Define the specific dataset directory
+dataset_dir = os.path.join(base_dir, "osv5m")
+
+# Ensure the specific dataset directory exists
+if not os.path.exists(dataset_dir):
+    os.mkdir(dataset_dir)
+
+# Download the dataset
+snapshot_download(repo_id="osv5m/osv5m", local_dir=dataset_dir, repo_type='dataset')
+
+# Extract zip files and remove them after extraction
+for root, dirs, files in os.walk(dataset_dir):
     for file in files:
         if file.endswith(".zip"):
             with zipfile.ZipFile(os.path.join(root, file), 'r') as zip_ref:


### PR DESCRIPTION
**Problem:**
When `download-dataset.py` is executed from the project root (e.g., `python scripts/download-dataset.py`), it fails to locate the `datasets` directory due to incorrect path handling.


**Changes:**
- Modified the base directory path setup using `os.getcwd()` to ensure it points to the project root.
- Added checks and creation logic for the base and dataset-specific directories to avoid runtime errors.
